### PR TITLE
Return empty instead of null if FileDialog fails to open

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/FileDialog.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/FileDialog.java
@@ -383,7 +383,7 @@ public Optional<String> openDialog () {
 	fullPath = null;
 	if ((style & SWT.SAVE) != 0) {
 		NSSavePanel savePanel = NSSavePanel.savePanel();
-		if (savePanel == null) return null;
+		if (savePanel == null) return Optional.empty();
 		panel = savePanel;
 		if (!overwrite) {
 			callback_overwrite_existing_file = new Callback(this, "_overwriteExistingFileCheck", 3);
@@ -395,7 +395,7 @@ public Optional<String> openDialog () {
 		}
 	} else {
 		NSOpenPanel openPanel = NSOpenPanel.openPanel();
-		if (openPanel == null) return null;
+		if (openPanel == null) return Optional.empty();
 		openPanel.setAllowsMultipleSelection((style & SWT.MULTI) != 0);
 		panel = openPanel;
 	}


### PR DESCRIPTION
For Cocoa if `NSSavePanel` or `NSOpenPanel` can't be created, return an empty Optional instead of `null` to prevent a `NullPointerException` in `FileDialog.open()`.

Fixes an issue with #588. 